### PR TITLE
Add auction helper contract

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,8 @@ jobs:
   forge:
     strategy:
       fail-fast: true
-
+    permissions:
+      pull-requests: write
     name: Foundry project
     runs-on: ubuntu-latest
     steps:

--- a/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
+++ b/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { IRngAuction } from "./interfaces/IRngAuction.sol";
+import { ChainlinkVRFV2Direct } from "./ChainlinkVRFV2Direct.sol";
+import { IERC20 } from "openzeppelin-contracts/interfaces/IERC20.sol";
+
+/// @notice Thrown if the ChainlinkVRFV2Direct contract is set to the zero address.
+error ChainlinkVRFV2DirectZeroAddress();
+
+/// @notice Thrown if the RngAuction contract is set to the zero address.
+error RngAuctionZeroAddress();
+
+/**
+ * @notice Thrown if the active RNG service of the RngAuction doesn't match the address of
+ * the ChainlinkVRFV2Direct contract.
+ * @param chainlinkVrfV2Direct The ChainlinkVRFV2Direct contract address
+ * @param activeRngService The active RNG service of the RngAuction
+ */
+error RngServiceNotActive(address chainlinkVrfV2Direct, address activeRngService);
+
+/**
+ * @title PoolTogether V5 ChainlinkVRFV2DirectRngAuctionHelper
+ * @author Generation Software Team
+ * @notice This is a helper contract to provide clients a simplified interface to interact
+ * with the RNGAuction if a fee needs to be transferred before starting the RNG request.
+ * @dev 
+ */
+contract ChainlinkVRFV2DirectRngAuctionHelper {
+
+    /// @notice The ChainlinkVRFV2Direct contract that the fee will be transferred to.
+    ChainlinkVRFV2Direct public immutable chainlinkVrfV2Direct;
+
+    /// @notice The RngAuction that will be completed after the fee is transferred.
+    IRngAuction public immutable rngAuction;
+
+    /**
+     * @notice Initializes the contract with the target ChainlinkVRFV2Direct and RngAuction
+     * contracts.
+     * @param _chainlinkVrfV2Direct The ChainlinkVRFV2Direct contract that the fee will be transferred to.
+     * @param _rngAuction The RngAuction contract that will be completed after the fee is transferred.
+     */
+    constructor (ChainlinkVRFV2Direct _chainlinkVrfV2Direct, IRngAuction _rngAuction) {
+        if (address(_chainlinkVrfV2Direct) == address(0)) revert ChainlinkVRFV2DirectZeroAddress();
+        if (address(_rngAuction) == address(0)) revert RngAuctionZeroAddress();
+        chainlinkVrfV2Direct = _chainlinkVrfV2Direct;
+        rngAuction = _rngAuction;
+    }
+
+    /**
+     * @notice Transfers the RNG fee from the caller to the ChainlinkVRFV2Direct contract before
+     * completing the RNG auction by starting the RNG request.
+     * @param _rewardRecipient Address that will receive the auction reward for starting the RNG request
+     * @dev Will revert if the active RNG service of the RngAuction does not match the ChainlinkVRFV2Direct
+     * contract address.
+     */
+    function transferFeeAndStartRngRequest(address _rewardRecipient) external {
+        if (address(rngAuction.getNextRngService()) != address(chainlinkVrfV2Direct)) {
+            revert RngServiceNotActive(address(chainlinkVrfV2Direct), address(rngAuction.getNextRngService()));
+        }
+        (address _feeToken, uint256 _requestFee) = chainlinkVrfV2Direct.getRequestFee();
+        IERC20(_feeToken).transferFrom(msg.sender, address(chainlinkVrfV2Direct), _requestFee);
+        rngAuction.startRngRequest(_rewardRecipient);
+    }
+
+}

--- a/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
+++ b/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { IRngAuction } from "./interfaces/IRngAuction.sol";
 import { ChainlinkVRFV2Direct } from "./ChainlinkVRFV2Direct.sol";
-import { IERC20 } from "openzeppelin-contracts/interfaces/IERC20.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 
 /// @notice Thrown if the ChainlinkVRFV2Direct contract is set to the zero address.
 error ChainlinkVRFV2DirectZeroAddress();

--- a/src/interfaces/IRngAuction.sol
+++ b/src/interfaces/IRngAuction.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { RNGInterface } from "rng-contracts/RNGInterface.sol";
+
+interface IRngAuction {
+    function startRngRequest(address _rewardRecipient) external;
+    function getNextRngService() external view returns (RNGInterface);
+}

--- a/test/ChainlinkVRFV2DirectRngAuctionHelper.t.sol
+++ b/test/ChainlinkVRFV2DirectRngAuctionHelper.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+
+import "../src/ChainlinkVRFV2DirectRngAuctionHelper.sol";
+import { ChainlinkVRFV2Direct } from "../src/ChainlinkVRFV2Direct.sol";
+
+import { ERC20Mintable } from "./mock/ERC20Mintable.sol";
+import { IRngAuction } from "../src/interfaces/IRngAuction.sol";
+import { RNGInterface } from "rng-contracts/RNGInterface.sol";
+
+contract ChainlinkVRFV2DirectRngAuctionHelperTest is Test {
+
+  /* ============ Variables ============ */
+  ChainlinkVRFV2DirectRngAuctionHelper public vrfHelper;
+  ChainlinkVRFV2Direct public vrfDirect;
+  IRngAuction public rngAuction;
+  ERC20Mintable public rngFeeToken;
+
+  /* ============ Setup ============ */
+  function setUp() public {
+    vm.warp(0);
+
+    rngFeeToken = new ERC20Mintable("RNG Fee Token", "RNGFT");
+
+    rngAuction = IRngAuction(makeAddr("rngAuction"));
+    vm.etch(address(rngAuction), "rngAuction");
+
+    vrfDirect = ChainlinkVRFV2Direct(makeAddr("vrfDirect"));
+    vm.etch(address(vrfDirect), "vrfDirect");
+
+    vrfHelper = new ChainlinkVRFV2DirectRngAuctionHelper(vrfDirect, rngAuction);
+  }
+
+  /* ============ Tests ============ */
+
+  /// @dev Tests if the constructor will revert if the VRF address is the zero address.
+  function testConstructorZeroVrfAddress() public {
+    vm.expectRevert(abi.encodeWithSelector(ChainlinkVRFV2DirectZeroAddress.selector));
+    new ChainlinkVRFV2DirectRngAuctionHelper(ChainlinkVRFV2Direct(address(0)), rngAuction);
+  }
+
+  /// @dev Tests if the constructor will revert if the RNG Auction address is the zero address.
+  function testConstructorZeroRngAuctionAddress() public {
+    vm.expectRevert(abi.encodeWithSelector(RngAuctionZeroAddress.selector));
+    new ChainlinkVRFV2DirectRngAuctionHelper(vrfDirect, IRngAuction(address(0)));
+  }
+
+  /// @dev Tests if the ChainlinkVRFV2Direct contract address is public to read.
+  function testReadVrfAddress() public {
+    assertEq(address(vrfHelper.chainlinkVrfV2Direct()), address(vrfDirect));
+  }
+
+  /// @dev Tests if the RNG Auction contract address is public to read.
+  function testReadAuctionAddress() public {
+    assertEq(address(vrfHelper.rngAuction()), address(rngAuction));
+  }
+
+  /// @dev Tests if the transfer of fees works as intended before the startRngRequest call
+  function testTransferFeeAndStartRngRequest() public {
+    uint256 _fee = 5000;
+
+    // mocks
+    _mockRngAuctionGetNextRngService(rngAuction, vrfDirect);
+    _mockChainlinkVrfV2DirectGetRequestFee(vrfDirect, address(rngFeeToken), _fee);
+    _mockRngAuctionStartRngRequest(rngAuction, address(this));
+    
+    // mint fee to this address
+    rngFeeToken.mint(address(this), _fee);
+
+    // test
+    rngFeeToken.approve(address(vrfHelper), _fee);
+    vrfHelper.transferFeeAndStartRngRequest(address(this));
+    assertEq(rngFeeToken.balanceOf(address(this)), 0);
+    assertEq(rngFeeToken.balanceOf(address(vrfDirect)), _fee);
+  }
+
+  /// @dev Tests if revert when RngService is no longer the expected chainlink VRF address.
+  function testTransferFeeAndStartRngRequestRngServiceNotActive() public {
+    uint256 _fee = 5000;
+
+    // mocks
+    _mockRngAuctionGetNextRngService(rngAuction, RNGInterface(address(2))); // mock to different address
+    _mockRngAuctionGetNextRngService(rngAuction, RNGInterface(address(2))); // mock to different address (second call)
+    _mockChainlinkVrfV2DirectGetRequestFee(vrfDirect, address(rngFeeToken), _fee);
+    _mockRngAuctionStartRngRequest(rngAuction, address(this));
+    
+    // mint fee to this address
+    rngFeeToken.mint(address(this), _fee);
+
+    // test
+    rngFeeToken.approve(address(vrfHelper), _fee);
+    vm.expectRevert(abi.encodeWithSelector(RngServiceNotActive.selector, address(vrfDirect), address(2)));
+    vrfHelper.transferFeeAndStartRngRequest(address(this));
+  }
+
+  /// @dev Tests if the transfer of fees fails if not approved.
+  function testTransferFeeAndStartRngRequestNotApproved() public {
+    uint256 _fee = 5000;
+
+    // mocks
+    _mockRngAuctionGetNextRngService(rngAuction, vrfDirect);
+    _mockChainlinkVrfV2DirectGetRequestFee(vrfDirect, address(rngFeeToken), _fee);
+    _mockRngAuctionStartRngRequest(rngAuction, address(this));
+    
+    // mint fee to this address
+    rngFeeToken.mint(address(this), _fee);
+
+    // test
+    rngFeeToken.approve(address(vrfHelper), 0); // zero approval
+    vm.expectRevert("ERC20: insufficient allowance");
+    vrfHelper.transferFeeAndStartRngRequest(address(this));
+  }
+
+  /// @dev Tests if the transfer of fees fails if not enough balance.
+  function testTransferFeeAndStartRngRequestNotEnoughBalance() public {
+    uint256 _fee = 5000;
+
+    // mocks
+    _mockRngAuctionGetNextRngService(rngAuction, vrfDirect);
+    _mockChainlinkVrfV2DirectGetRequestFee(vrfDirect, address(rngFeeToken), _fee);
+    _mockRngAuctionStartRngRequest(rngAuction, address(this));
+    
+    // burn all tokens
+    rngFeeToken.transfer(address(1), rngFeeToken.balanceOf(address(this)));
+
+    // test
+    rngFeeToken.approve(address(vrfHelper), _fee);
+    vm.expectRevert("ERC20: transfer amount exceeds balance");
+    vrfHelper.transferFeeAndStartRngRequest(address(this));
+  }
+
+  /* ============ Mocks ============ */
+
+  function _mockRngAuctionGetNextRngService(IRngAuction _rngAuction, RNGInterface _nextRngInterface) internal {
+    vm.mockCall(
+      address(_rngAuction),
+      abi.encodeWithSelector(IRngAuction.getNextRngService.selector),
+      abi.encode(_nextRngInterface)
+    );
+  }
+
+  function _mockRngAuctionStartRngRequest(IRngAuction _rngAuction, address _rewardRecipient) internal {
+    vm.mockCall(
+      address(_rngAuction),
+      abi.encodeWithSelector(IRngAuction.startRngRequest.selector, _rewardRecipient),
+      abi.encode(0)
+    );
+  }
+
+  function _mockChainlinkVrfV2DirectGetRequestFee(ChainlinkVRFV2Direct _chainlinkVrfV2Direct, address _feeToken, uint256 _fee) internal {
+    vm.mockCall(
+      address(_chainlinkVrfV2Direct),
+      abi.encodeWithSelector(ChainlinkVRFV2Direct.getRequestFee.selector),
+      abi.encode(_feeToken, _fee)
+    );
+  }
+
+}

--- a/test/mock/ERC20Mintable.sol
+++ b/test/mock/ERC20Mintable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.19;
+
+import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";
+
+contract ERC20Mintable is ERC20 {
+  constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {}
+
+  function mint(address _account, uint256 _amount) public {
+    _mint(_account, _amount);
+  }
+}


### PR DESCRIPTION
### Summary

Adds a Helper contract that will be the point of entry for bots looking to start an RNG request through the RngAuction. Instead of interacting directly with the RngAuction contract, the bots should interact with the helper contract while this RNG service is active (if the service ever changes, this contract is designed to fail any requests to prevent loss of funds).

The helper contract has a function `transferFeeAndStartRngRequest` which will transfer the required fee from the caller to the RNG service before completing the RngAuction. The caller is expected to have approved the helper contract to spend their LINK tokens before calling.