### PR TITLE
add estimateRequestFee function to helper contract

### DIFF
--- a/src/ChainlinkVRFV2Direct.sol
+++ b/src/ChainlinkVRFV2Direct.sol
@@ -123,8 +123,8 @@ contract ChainlinkVRFV2Direct is VRFV2WrapperConsumerBase, Ownable, RNGInterface
 
   /**
    * @notice Returns the timestamp at which the passed `requestId` was completed.
-   * @param requestId The ID of the request
    * @dev Returns zero if not completed or if the request doesn't exist
+   * @param requestId The ID of the request
    */
   function completedAt(uint32 requestId) external view returns (uint64 completedAtTimestamp) {
     return _requestCompletedAt[requestId];

--- a/src/ChainlinkVRFV2Direct.sol
+++ b/src/ChainlinkVRFV2Direct.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import { VRFV2WrapperConsumerBase } from "chainlink/vrf/VRFV2WrapperConsumerBase.sol";
 import { Ownable } from "owner-manager/Ownable.sol";
 
-import { VRFV2WrapperInterface } from "chainlink/interfaces/VRFV2WrapperInterface.sol";
+import { VRFV2Wrapper } from "chainlink/vrf/VRFV2Wrapper.sol";
 import { LinkTokenInterface } from "chainlink/interfaces/LinkTokenInterface.sol";
 import { RNGInterface } from "rng-contracts/RNGInterface.sol";
 
@@ -35,7 +35,7 @@ contract ChainlinkVRFV2Direct is VRFV2WrapperConsumerBase, Ownable, RNGInterface
   /// @notice Thrown when the LINK token contract address is set to the zero address.
   error LinkTokenZeroAddress();
 
-  /// @notice Thrown when the VRFV2WrapperInterface address is set to the zero address.
+  /// @notice Thrown when the VRFV2Wrapper address is set to the zero address.
   error VRFV2WrapperZeroAddress();
 
   /// @notice Thrown when the callback gas limit is set to zero.
@@ -63,19 +63,16 @@ contract ChainlinkVRFV2Direct is VRFV2WrapperConsumerBase, Ownable, RNGInterface
   /**
    * @notice Constructor of the contract
    * @param _owner Address of the contract owner
-   * @param _linkToken Address of the LINK token contract
    * @param _vrfV2Wrapper Address of the VRF V2 Wrapper
    * @param callbackGasLimit_ Gas limit for the fulfillRandomWords callback
    * @param requestConfirmations_ The number of confirmations to wait before fulfilling the request
    */
   constructor(
     address _owner,
-    LinkTokenInterface _linkToken,
-    VRFV2WrapperInterface _vrfV2Wrapper,
+    VRFV2Wrapper _vrfV2Wrapper,
     uint32 callbackGasLimit_,
     uint16 requestConfirmations_
-  ) VRFV2WrapperConsumerBase(address(_linkToken), address(_vrfV2Wrapper)) Ownable(_owner) {
-    if (address(_linkToken) == address(0)) revert LinkTokenZeroAddress();
+  ) VRFV2WrapperConsumerBase(address(_vrfV2Wrapper.LINK()), address(_vrfV2Wrapper)) Ownable(_owner) {
     if (address(_vrfV2Wrapper) == address(0)) revert VRFV2WrapperZeroAddress();
     _setCallbackGasLimit(callbackGasLimit_);
     _setRequestConfirmations(requestConfirmations_);
@@ -153,6 +150,12 @@ contract ChainlinkVRFV2Direct is VRFV2WrapperConsumerBase, Ownable, RNGInterface
   /// @return The current request confirmation count
   function getRequestConfirmations() external view returns (uint16) {
     return _requestConfirmations;
+  }
+
+  /// @notice Returns the VRF V2 Wrapper contract that this contract uses.
+  /// @return The VRFV2Wrapper contract
+  function vrfV2Wrapper() external view returns (VRFV2Wrapper) {
+    return VRFV2Wrapper(address(VRF_V2_WRAPPER));
   }
 
   /* ============ External Setters ============ */

--- a/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
+++ b/src/ChainlinkVRFV2DirectRngAuctionHelper.sol
@@ -25,7 +25,6 @@ error RngServiceNotActive(address chainlinkVrfV2Direct, address activeRngService
  * @author Generation Software Team
  * @notice This is a helper contract to provide clients a simplified interface to interact
  * with the RNGAuction if a fee needs to be transferred before starting the RNG request.
- * @dev 
  */
 contract ChainlinkVRFV2DirectRngAuctionHelper {
 
@@ -51,12 +50,12 @@ contract ChainlinkVRFV2DirectRngAuctionHelper {
     /**
      * @notice Transfers the RNG fee from the caller to the ChainlinkVRFV2Direct contract before
      * completing the RNG auction by starting the RNG request.
-     * @param _rewardRecipient Address that will receive the auction reward for starting the RNG request
      * @dev Will revert if the active RNG service of the RngAuction does not match the ChainlinkVRFV2Direct
      * contract address.
      * @dev To estimate the request fee, use the `estimateRequestFee(...)` function on this contract.
      * @dev DO NOT USE THE `getRequestFee()` FUNCTION ON THE RNG SERVICE TO PREDICT THE FEE AS IT REQUIRES A
      * TX GAS PRICE TO CALCULATE THE CORRECT VALUE!
+     * @param _rewardRecipient Address that will receive the auction reward for starting the RNG request
      */
     function transferFeeAndStartRngRequest(address _rewardRecipient) external {
         if (address(rngAuction.getNextRngService()) != address(chainlinkVrfV2Direct)) {
@@ -69,10 +68,10 @@ contract ChainlinkVRFV2DirectRngAuctionHelper {
 
     /**
      * @notice Estimates the RNG request fee in LINK based on the expected gas price.
+     * @dev Use this function instead of `RNGInterface.getRequestFee()` when estimating request fees offchain.
      * @param _gasPrice The gas price to calculate the request fee for
      * @return _feeToken The LINK address
      * @return _requestFee The estimated request fee based on the given gas price
-     * @dev Use this function instead of `RNGInterface.getRequestFee()` when estimating request fees offchain.
      */
     function estimateRequestFee(uint256 _gasPrice) external returns (address _feeToken, uint256 _requestFee) {
         VRFV2Wrapper wrapper = chainlinkVrfV2Direct.vrfV2Wrapper();

--- a/test/ChainlinkVRFV2Direct.t.sol
+++ b/test/ChainlinkVRFV2Direct.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import "forge-std/Test.sol";
 
 import { ChainlinkVRFV2Direct } from "../src/ChainlinkVRFV2Direct.sol";
-import { VRFV2WrapperInterface } from "chainlink/interfaces/VRFV2WrapperInterface.sol";
+import { VRFV2Wrapper } from "chainlink/vrf/VRFV2Wrapper.sol";
 import { LinkTokenInterface } from "chainlink/interfaces/LinkTokenInterface.sol";
 
 contract ChainlinkVRFV2DirectTest is Test {
@@ -19,7 +19,7 @@ contract ChainlinkVRFV2DirectTest is Test {
   /// @notice Thrown when the LINK token contract address is set to the zero address.
   error LinkTokenZeroAddress();
 
-  /// @notice Thrown when the VRFV2WrapperInterface address is set to the zero address.
+  /// @notice Thrown when the VRFV2Wrapper address is set to the zero address.
   error VRFV2WrapperZeroAddress();
 
   /// @notice Thrown when the callback gas limit is set to zero.
@@ -85,7 +85,7 @@ contract ChainlinkVRFV2DirectTest is Test {
   function testIsRequestComplete() external {
     useMainnet();
     (uint32 _requestId, uint32 _lockBlock) = requestRandomNumberMainnet();
-    uint256 _wrapperRequestId = VRFV2WrapperInterface(wrapperMainnet).lastRequestId();
+    uint256 _wrapperRequestId = VRFV2Wrapper(wrapperMainnet).lastRequestId();
     assertEq(vrfDirect.isRequestComplete(_requestId), false);
 
     // Fulfill randomness
@@ -99,7 +99,7 @@ contract ChainlinkVRFV2DirectTest is Test {
   function testCompletedAt() external {
     useMainnet();
     (uint32 _requestId, uint32 _lockBlock) = requestRandomNumberMainnet();
-    uint256 _wrapperRequestId = VRFV2WrapperInterface(wrapperMainnet).lastRequestId();
+    uint256 _wrapperRequestId = VRFV2Wrapper(wrapperMainnet).lastRequestId();
     assertEq(vrfDirect.completedAt(_requestId), 0);
 
     // Fulfill randomness
@@ -114,7 +114,7 @@ contract ChainlinkVRFV2DirectTest is Test {
   function testRandomNumber() external {
     useMainnet();
     (uint32 _requestId, uint32 _lockBlock) = requestRandomNumberMainnet();
-    uint256 _wrapperRequestId = VRFV2WrapperInterface(wrapperMainnet).lastRequestId();
+    uint256 _wrapperRequestId = VRFV2Wrapper(wrapperMainnet).lastRequestId();
     assertEq(vrfDirect.randomNumber(_requestId), 0);
 
     // Fulfill randomness
@@ -193,7 +193,7 @@ contract ChainlinkVRFV2DirectTest is Test {
   function testFulfillRandomWords_InvalidRequestId() external {
     useMainnet();
     requestRandomNumberMainnet();
-    uint256 _wrapperRequestId = VRFV2WrapperInterface(wrapperMainnet).lastRequestId();
+    uint256 _wrapperRequestId = VRFV2Wrapper(wrapperMainnet).lastRequestId();
     uint256 _badId = _wrapperRequestId + 1;
 
     vm.startPrank(wrapperMainnet);
@@ -204,6 +204,12 @@ contract ChainlinkVRFV2DirectTest is Test {
     vm.stopPrank();
   }
 
+  /* ============ vrfV2Wrapper() ============ */
+  function testVrfV2Wrapper() external {
+    useMainnet();
+    assertEq(address(vrfDirect.vrfV2Wrapper()), address(wrapperMainnet));
+  }
+
   /* ============ Helpers ============ */
 
   /// @dev Run at the beginning of each fork test
@@ -211,8 +217,7 @@ contract ChainlinkVRFV2DirectTest is Test {
     vm.selectFork(mainnetFork);
     vrfDirect = new ChainlinkVRFV2Direct(
       address(this),
-      LinkTokenInterface(address(linkMainnet)),
-      VRFV2WrapperInterface(address(wrapperMainnet)),
+      VRFV2Wrapper(address(wrapperMainnet)),
       callbackGasLimit,
       requestConfirmations
     );


### PR DESCRIPTION
- Also use VRFV2Wrapper instead of equivalent interface so we can access VRFV2Wrapper.LINK()
- Constructor no longer needs LINK token address passed in since it pulls it directly from the wrapper

### Motivation
Bots can't use the `RNGInterface.getRequestFee()` function to estimate the LINK fee for the chainlink implementation since it only works if `tx.gasprice` is set (during a TX). To provide a simple interface for bots to *estimate offchain* the LINK fee for the request, we add a function to the chainlink helper contract called `estimateRequestFee` that takes in an expected gas price, configurable by the bot, and returns the LINK fee if that gas price were to be used.